### PR TITLE
Fix nodejs dependency installation

### DIFF
--- a/ci.py
+++ b/ci.py
@@ -312,7 +312,7 @@ def application_code_changed():
 # -------
 def fetch_dependencies():
     print(f"🧲\t{COL_YEL}Fetching{COL_END} dependencies...")
-    descriptor = copy2(CURRENT_PACKAGES_DESCRIPTOR_PATH, f"{WORKING_DIR}/current-{DESCRIPTORS[LANGUAGE]}")
+    descriptor = copy2(CURRENT_PACKAGES_DESCRIPTOR_PATH, f"{WORKING_DIR}/{DESCRIPTORS[LANGUAGE]}")
     descriptor = os.path.basename(descriptor)
     if LANGUAGE == "python":
         pip(descriptor)


### PR DESCRIPTION
If you try to deploy nodejs you will get this error:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.8/Frameworks/Python.framework/Versions/3.9/lib/python3.9/shutil.py", line 815, in move
    os.rename(src, real_dst)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/lambda-ci/7bs1u2n7/node_modules' -> '/tmp/lambda-ci/7bs1u2n7/nodejs/node_modules'
```

this happens because "npm install" is looking for a package.json file (not current-package.json)